### PR TITLE
feat: added docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine
+
+WORKDIR /pizza-cubed
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+RUN npm run build
+
+CMD npm start

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+version: "3.8"
+
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: pizzaCubed_mongodb
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/home/pizza-cubed/data/db
+
+  nextjs:
+    build: .
+    container_name: pizzaCubed_nextJs
+    ports:
+      - "3000:3000"
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
This PR dockerize the nextJs app, with mongoDb support.
After launching `Docker engine` , run the following `cmd` in your terminal:
`docker-compose up` and check the application in your browser  `localhost:3000`